### PR TITLE
fix: gateway url api v2

### DIFF
--- a/rocketreach/gateway.py
+++ b/rocketreach/gateway.py
@@ -71,7 +71,7 @@ class Gateway:
         if self.version == 1:
             self.url_prefix = f'{self.url_prefix}/v1/api'
         else:
-            self.url_prefix = f'{self.url_prefix}/api/v2'
+            self.url_prefix = f'{self.url_prefix}/v2/api'
 
     def get_url(self, path: str):
         path = path.rstrip('/').lstrip('/')

--- a/rocketreach/version.py
+++ b/rocketreach/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.1.4'
+VERSION = '2.1.5'


### PR DESCRIPTION
I was trying to use the simple search example in the SDK reference but always get the error from this issue: https://github.com/rocketreach/rocketreach_python/issues/2

The request is completely valid but the old URL returns a 404 status code with an unprocessable HTML as JSON 